### PR TITLE
Web3 action to watch registered contract and auto-place orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This repository defined a common interface (`ConditionalOrder`) that all smart o
 - [Foundry](https://github.com/foundry-rs/foundry)
 - node (v16.18.0)
 - yarn
+- npm
+- [Tenderly](https://docs.tenderly.co/monitoring/integrations#installing-on-macos)[^1]
+- node[^1]
+
+[^1]: only when touching Web3 actions
 
 ## How to build/deploy an existing order type
 
@@ -31,6 +36,16 @@ Check `src/` for a full list and implementation details. In order to deploy one 
 
 The deployed contract should automatically be picked up by a watchdog and - once it returns a tradable order - find itself automatically placing this order. The status of placed orders by this contract can be observed on https://explorer.cow.fi/.
 
+### Debugging in case an order doesn't get created
+
+You can simulate the outcome of the watchdog locally by running
+
+```
+yarn check-deployment <deployed contract address>
+```
+
+This will give you the response of a single run of the watchdog (it will also create an order if possible). If this script passes, but you still don't see orders being placed automatically, please contact us.
+
 ## Writing your own Smart Order
 
 You are more than welcome to create new order types. For this simply create a new smart contract implementation in the `src/` folder (with an accompanying test contract in `/test`) and start hacking. 
@@ -40,3 +55,17 @@ Your contract should inherit from `ConditionalOrder` and `EIP1271Verifier`. This
 Look at other example contracts for help/inspiration. To test your contract and make sure they comply with our style-guides please run:
 1. `forge test`
 2. `yarn fmt`
+
+Once created, you can deploy your own smart orders just like existing order types as described 👆
+
+## Deploying Tenderly Actions
+
+This is only needed if you want to operate your own watchdog. In this case, please consider using a different trigger event, to avoid other watchdogs from monitoring the same contract. You also may have the project name if you are not part of the gp-v2 organisation.
+
+When making changes to the tenderly actions, a good way to test them locally is by writing a [test script](https://docs.tenderly.co/web3-actions/references/local-development-and-testing).
+
+Once ready to deploy, run
+
+```
+tenderly actions deploy
+```

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -1,0 +1,31 @@
+import { TestBlockEvent, TestRuntime } from "@tenderly/actions-test";
+import { checkForAndPlaceOrder } from "../watch";
+import { Registry } from "../register";
+import { ethers } from "ethers";
+
+const main = async () => {
+  const testRuntime = new TestRuntime();
+  const testEvent = new TestBlockEvent();
+
+  const contractUnderTest = process.argv[2];
+  const node_url = process.env["ETH_RPC_URL"];
+  if (!node_url) {
+    throw "Please specify your node url via the ETH_RPC_URL env variable";
+  }
+
+  // The web3 actions fetches the node url and computes the API based on the current chain id
+  const provider = new ethers.providers.JsonRpcProvider(node_url);
+  const { chainId } = await provider.getNetwork();
+  testEvent.network = chainId.toString();
+  await testRuntime.context.secrets.put(`NODE_URL_${chainId}`, node_url);
+
+  // Register the contract that was passed in from the command line to be watched
+  const registry = await Registry.load(testRuntime.context, testEvent.network);
+  registry.contracts.push(contractUnderTest);
+  await registry.write();
+
+  // run action
+  await testRuntime.execute(checkForAndPlaceOrder, testEvent);
+};
+
+(async () => await main())();

--- a/actions/watch.ts
+++ b/actions/watch.ts
@@ -1,0 +1,126 @@
+import { ActionFn, BlockEvent, Context, Event } from "@tenderly/actions";
+
+import axios from "axios";
+import { OrderKind } from "@cowprotocol/contracts";
+import { ethers } from "ethers";
+import { abi } from "./artifacts/ConditionalOrder.json";
+import { Registry } from "./register";
+
+export const checkForAndPlaceOrder: ActionFn = async (
+  context: Context,
+  event: Event
+) => {
+  const blockEvent = event as BlockEvent;
+  const registry = await Registry.load(context, blockEvent.network);
+  const chainContext = await ChainContext.create(context, blockEvent.network);
+  for (const contract_address of registry.contracts) {
+    console.log(`Checking ${contract_address}`);
+    const contract = new ethers.Contract(
+      contract_address,
+      abi,
+      chainContext.provider
+    );
+    try {
+      const order = await contract.getTradeableOrder();
+      const signature = contract.interface.encodeFunctionResult(
+        "getTradeableOrder()",
+        [Array.from(order)]
+      );
+      console.log(`Placing Order...`);
+      await placeOrder(
+        { ...order, from: contract_address, signature },
+        chainContext.api_url
+      );
+    } catch (e) {
+      console.log(`Not tradeable (${e})`);
+    }
+  }
+};
+
+async function placeOrder(order: any, api_url: string) {
+  try {
+    const { data } = await axios.post(
+      `${api_url}/api/v1/orders`,
+      {
+        sellToken: order.sellToken,
+        buyToken: order.buyToken,
+        receiver: order.receiver,
+        sellAmount: order.sellAmount.toString(),
+        buyAmount: order.buyAmount.toString(),
+        validTo: order.validTo,
+        appData: order.appData,
+        feeAmount: order.feeAmount.toString(),
+        kind: orderKind(order),
+        partiallyFillable: order.partiallyFillable,
+        signature: order.signature,
+        signingScheme: "eip1271",
+        from: order.from,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          accept: "application/json",
+        },
+      }
+    );
+    console.log(`API response: ${data}`);
+  } catch (error: any) {
+    if (error.response) {
+      // The request was made and the server responded with a status code
+      // that falls out of the range of 2xx
+      console.log(error.response.status);
+      console.log(error.response.data);
+    } else if (error.request) {
+      // The request was made but no response was received
+      // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+      // http.ClientRequest in node.js
+      console.log(error.request);
+    } else if (error.message) {
+      // Something happened in setting up the request that triggered an Error
+      console.log("Error", error.message);
+    } else {
+      console.log(error);
+    }
+  }
+}
+
+function orderKind(order: any): OrderKind {
+  for (const kind of [OrderKind.BUY, OrderKind.SELL]) {
+    if (order.kind == ethers.utils.id(kind)) {
+      return kind;
+    }
+  }
+  throw "Unexpected order kind";
+}
+
+class ChainContext {
+  provider: ethers.providers.Provider;
+  api_url: string;
+
+  constructor(provider: ethers.providers.Provider, api_url: string) {
+    this.provider = provider;
+    this.api_url = api_url;
+  }
+
+  public static async create(
+    context: Context,
+    network: string
+  ): Promise<ChainContext> {
+    const node_url = await context.secrets.get(`NODE_URL_${network}`);
+    const provider = new ethers.providers.JsonRpcProvider(node_url);
+    return new ChainContext(provider, apiUrl(network));
+  }
+}
+
+function apiUrl(network: string): string {
+  switch (network) {
+    case "1":
+      return "https://barn.api.cow.fi/mainnet";
+    case "5":
+      return "https://barn.api.cow.fi/goerli";
+    case "100":
+      return "https://barn.api.cow.fi/xdai";
+    default:
+      throw "Unsupported network";
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "fmt:contracts": "prettier 'src/**/*.sol' -w && prettier 'test/**/*.sol' -w",
     "lint:contracts": "solhint 'src/**/*.sol' 'test/**/*.sol'",
     "fmt:actions": "prettier ./actions -w",
+    "build:actions": "cd actions && npm ci && yarn run build",
     "lint:actions": "eslint && prettier --check ./actions",
-    "test:actions": "cd actions && npm ci && yarn run build && ts-node test/test_register.ts"
+    "test:actions": "yarn build:actions && ts-node actions/test/test_register.ts",
+    "check-deployment": "yarn build:actions && ts-node actions/test/run_local.ts"
   }
 }

--- a/tenderly.yaml
+++ b/tenderly.yaml
@@ -22,4 +22,15 @@ actions:
                 logEmitted:
                   startsWith: 
                   - 0xa463d4c6494f3788b95f6cf2a5c8c1a63090dce890c49318a6f5f32dc51efcd1 
+      watch_orders:
+        description: Checks on every block if the registered smart order contract wants to trade
+        function: watch:checkForAndPlaceOrder
+        trigger:
+          type: block
+          block:
+            network:
+              - 1
+              - 5
+              - 100
+            blocks: 5
 project_slug: ""


### PR DESCRIPTION
Now that we have a registry for contracts we want to observe, we can create another web3 action, that periodically - every 5 blocks for now - checks if any of the registered contracts wants to make a trade. If so, it places the order in our API.

### Test Plan

Deploy a `TradeAboveThreshold` contract, send it some of the specified sell token (more than threshold). Observe it automatically creating a trade like: https://explorer.cow.fi/goerli/orders/0x5b141ea6603743581322de5141108beab76d3b11f1de953d8d9b72e9b3353329fad2ad22203c28f9fcd1973f2d037a331d8ba416639504e4