### PR TITLE
Rewriting `TradeAfterThreshold` to work with Safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ yarn check-deployment <deployed contract address>
 
 This will give you the response of a single run of the watchdog (it will also create an order if possible). If this script passes, but you still don't see orders being placed automatically, please contact us.
 
+## Using Smart Orders with your (Gnosis) Safe
+
+In order to keep the smart order logic minimal and not worry about funding, withdrawing, updating ownership of the smart order, it can be beneficial to use a [Safe Contract](https://app.safe.global/) as the main trading contract.
+
+Safes allow for a custom "fallback handler" that is used to verify signatures and can be used to implement arbitrary ERC1271 logic, such as the one implemented by our conditional orders for CoW Protocol trade verification.
+
+The Safe contracts have been battle tested and come with fully configurable custody access, ownership management, etc. out of the box. We recommend using a fresh Safe for each order as changing the fallback handler can have an impact on other use cases that the Safe requires ERC1271 signatures for (this could be solved by using a "fallback handler chain" which goes beyond the scope of this document).
+
+Order types that support being used with Safe should come with a factory contract that allows creating new instances via the transaction builder in the Safe UI (rather than requiring command line interactions).
+
+To deploy, e.g. a `TradeAboveThreshold` smart order safe, do the following:
+
+1. Create a new Safe
+2. Set allowance on CoW Swap for the token you are looking to sell (e.g. via the CoW Swap Safe App)
+3. Using the transaction builder, call the `TradeAboveThresholdFactory` (may have to be deployed) to create a custom `TradeAboveThreshold` instance using your Safe address as the target (remaining parameters according to your use case)
+4. Once the `TradeAboveThreshold` is created, use the transaction builder to create another transaction, this time on your Safe itself, to `setFallbackHandler` to the address of the newly created `TradeAboveThreshold` instance.
+
+Once the Safe meets the condition to trade, an order on its behalf should be automatically placed.
+
+
 ## Writing your own Smart Order
 
 You are more than welcome to create new order types. For this simply create a new smart contract implementation in the `src/` folder (with an accompanying test contract in `/test`) and start hacking. 

--- a/actions/register.ts
+++ b/actions/register.ts
@@ -18,7 +18,7 @@ export const addContract: ActionFn = async (context: Context, event: Event) => {
 
   transactionEvent.logs.forEach((log) => {
     if (log.topics[0] === iface.getEventTopic("ConditionalOrderCreated")) {
-      const contract = log.address;
+      const contract = iface.decodeEventLog("ConditionalOrderCreated", log.data, log.topics)[0]
       if (
         registry.contracts.find((existing: string) => existing == contract) ===
         undefined

--- a/actions/register.ts
+++ b/actions/register.ts
@@ -18,7 +18,11 @@ export const addContract: ActionFn = async (context: Context, event: Event) => {
 
   transactionEvent.logs.forEach((log) => {
     if (log.topics[0] === iface.getEventTopic("ConditionalOrderCreated")) {
-      const contract = iface.decodeEventLog("ConditionalOrderCreated", log.data, log.topics)[0]
+      const contract = iface.decodeEventLog(
+        "ConditionalOrderCreated",
+        log.data,
+        log.topics
+      )[0];
       if (
         registry.contracts.find((existing: string) => existing == contract) ===
         undefined

--- a/actions/test/test_register.ts
+++ b/actions/test/test_register.ts
@@ -3,23 +3,23 @@ import {
   TestLog,
   TestRuntime,
 } from "@tenderly/actions-test";
-import { assert } from "console";
+import { strict as assert } from 'node:assert';
 import { addContract, storageKey } from "../register";
 
 const main = async () => {
   const testRuntime = new TestRuntime();
 
-  // https://gnosisscan.io/tx/0x9f20f13c80cf89604763ad0aed86bfd6f647e1ecd5da1921e7fe09ff3664a3ec#eventlog
+  // https://goerli.etherscan.io/tx/0xa0f618eea9c1195a7023835bd0306a6ead63fbdb37dd638402e684d0c52220a7#eventlog
   const alreadyIndexedLog = new TestLog();
-  alreadyIndexedLog.address = "0x75748d1774e768370d67571d5ac954c3cf3114c2";
   alreadyIndexedLog.topics = [
-    "0xa463d4c6494f3788b95f6cf2a5c8c1a63090dce890c49318a6f5f32dc51efcd1",
+    "0x348a1454f658b360fcb291e66a7adc4a65b64b38b956802a976d5e460d0e2084",
+    "0x00000000000000000000000051fcd11117bc85c319fd2848b301bbf6bc2b630f"
   ];
 
   const newLog = new TestLog();
-  newLog.address = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
   newLog.topics = [
-    "0xa463d4c6494f3788b95f6cf2a5c8c1a63090dce890c49318a6f5f32dc51efcd1",
+    "0x348a1454f658b360fcb291e66a7adc4a65b64b38b956802a976d5e460d0e2084",
+    "0x000000000000000000000000EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
   ];
 
   const event = new TestTransactionEvent();
@@ -28,7 +28,7 @@ const main = async () => {
   event.network = "mainnet";
 
   await testRuntime.context.storage.putJson(storageKey(event.network), {
-    contracts: ["0x75748d1774e768370d67571d5ac954c3cf3114c2"],
+    contracts: ["0x51fCD11117bC85C319FD2848B301BbF6bC2b630f"],
   });
 
   await testRuntime.execute(addContract, event);
@@ -42,7 +42,7 @@ const main = async () => {
     "Incorrect amount of contracts indexed"
   );
   assert(
-    storage.contracts[0] == "0x75748d1774e768370d67571d5ac954c3cf3114c2",
+    storage.contracts[0] == "0x51fCD11117bC85C319FD2848B301BbF6bC2b630f",
     "Missing already indexed contract"
   );
   assert(

--- a/actions/test/test_register.ts
+++ b/actions/test/test_register.ts
@@ -3,7 +3,7 @@ import {
   TestLog,
   TestRuntime,
 } from "@tenderly/actions-test";
-import { strict as assert } from 'node:assert';
+import { strict as assert } from "node:assert";
 import { addContract, storageKey } from "../register";
 
 const main = async () => {
@@ -13,7 +13,7 @@ const main = async () => {
   const alreadyIndexedLog = new TestLog();
   alreadyIndexedLog.topics = [
     "0x348a1454f658b360fcb291e66a7adc4a65b64b38b956802a976d5e460d0e2084",
-    "0x00000000000000000000000051fcd11117bc85c319fd2848b301bbf6bc2b630f"
+    "0x00000000000000000000000051fcd11117bc85c319fd2848b301bbf6bc2b630f",
   ];
 
   const newLog = new TestLog();

--- a/actions/watch.ts
+++ b/actions/watch.ts
@@ -26,7 +26,7 @@ export const checkForAndPlaceOrder: ActionFn = async (
         "getTradeableOrder()",
         [Array.from(order)]
       );
-      console.log(`Placing Order...`);
+      console.log(`Placing Order: ${order}`);
       await placeOrder(
         { ...order, from: contract_address, signature },
         chainContext.api_url

--- a/src/ConditionalOrder.sol
+++ b/src/ConditionalOrder.sol
@@ -6,9 +6,9 @@ import "lib/contracts/src/contracts/libraries/GPv2Order.sol";
 
 interface ConditionalOrder {
     /// Event that should be emitted in constructor so that the service "watching" for conditional orders can start indexing it
-    event ConditionalOrderCreated();
+    event ConditionalOrderCreated(address indexed);
 
-    /// Returns an order that if posted to the CoW Protocol API would pass validation
+    /// Returns an order that if posted to the CoW Protocol API would pass signature validation
     /// Reverts in case current order condition is not met
     function getTradeableOrder() external view returns (GPv2Order.Data memory);
 }

--- a/src/TradeAboveThreshold.sol
+++ b/src/TradeAboveThreshold.sol
@@ -6,25 +6,29 @@ import "./ConditionalOrder.sol";
 import "lib/contracts/src/contracts/GPv2Settlement.sol";
 import "lib/contracts/src/contracts/interfaces/GPv2EIP1271.sol";
 
+// @title A smart contract that trades whenever its balance of a certain token exceeds a target threshold
 contract TradeAboveThreshold is ConditionalOrder, EIP1271Verifier {
     using GPv2Order for GPv2Order.Data;
 
     IERC20 public immutable sellToken;
     IERC20 public immutable buyToken;
-    address public immutable receiver;
-    uint256 public immutable threshold;
-    bytes32 public domainSeparator;
+    address public immutable target;
+    uint256 immutable threshold;
+    bytes32 domainSeparator;
 
     constructor(
         IERC20 _sellToken,
         IERC20 _buyToken,
-        address _receiver,
+        address _target,
         uint256 _threshold,
         GPv2Settlement _settlementContract
     ) {
         sellToken = _sellToken;
         buyToken = _buyToken;
-        receiver = _receiver;
+        if (_target == address(0)) {
+            _target = address(this);
+        }
+        target = _target;
         threshold = _threshold;
         domainSeparator = _settlementContract.domainSeparator();
         _sellToken.approve(
@@ -32,16 +36,18 @@ contract TradeAboveThreshold is ConditionalOrder, EIP1271Verifier {
             uint(-1)
         );
 
-        emit ConditionalOrderCreated();
+        emit ConditionalOrderCreated(_target);
     }
 
+    // @dev If the `target`'s balance of `sellToken` is above the specified threshold, sell its entire balance
+    // for `buyToken` at the current market price (no limit!).
     function getTradeableOrder()
         external
         view
         override
         returns (GPv2Order.Data memory)
     {
-        uint256 balance = sellToken.balanceOf(address(this));
+        uint256 balance = sellToken.balanceOf(target);
         require(balance >= threshold, "Not enough balance");
         // ensures that orders queried shortly after one another result in the same hash (to avoid spamming the orderbook)
         // solhint-disable-next-line not-rely-on-time
@@ -50,7 +56,7 @@ contract TradeAboveThreshold is ConditionalOrder, EIP1271Verifier {
             GPv2Order.Data(
                 sellToken,
                 buyToken,
-                receiver,
+                target,
                 balance,
                 1, // 0 buy amount is not allowed
                 currentTimeBucket + 900, // between 15 and 30 miunte validity

--- a/src/TradeAboveThreshold.sol
+++ b/src/TradeAboveThreshold.sol
@@ -13,8 +13,8 @@ contract TradeAboveThreshold is ConditionalOrder, EIP1271Verifier {
     IERC20 public immutable sellToken;
     IERC20 public immutable buyToken;
     address public immutable target;
-    uint256 immutable threshold;
-    bytes32 domainSeparator;
+    uint256 public immutable threshold;
+    bytes32 public domainSeparator;
 
     constructor(
         IERC20 _sellToken,

--- a/src/factories/TradeAboveThresholdFactory.sol
+++ b/src/factories/TradeAboveThresholdFactory.sol
@@ -6,7 +6,7 @@ import "../TradeAboveThreshold.sol";
 
 // @title A factory to create `TradeAboveThreshold` order instances
 contract TradeAboveThresholdFactory {
-    GPv2Settlement constant SETTLEMENT_CONTRACT =
+    GPv2Settlement public constant SETTLEMENT_CONTRACT =
         GPv2Settlement(0x9008D19f58AAbD9eD0D60971565AA8510560ab41);
 
     function create(

--- a/src/factories/TradeAboveThresholdFactory.sol
+++ b/src/factories/TradeAboveThresholdFactory.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "../TradeAboveThreshold.sol";
+
+// @title A factory to create `TradeAboveThreshold` order instances
+contract TradeAboveThresholdFactory {
+    GPv2Settlement constant SETTLEMENT_CONTRACT =
+        GPv2Settlement(0x9008D19f58AAbD9eD0D60971565AA8510560ab41);
+
+    function create(
+        IERC20 sellToken,
+        IERC20 buyToken,
+        address target,
+        uint256 threshold
+    ) external returns (TradeAboveThreshold) {
+        return
+            new TradeAboveThreshold(
+                sellToken,
+                buyToken,
+                target,
+                threshold,
+                SETTLEMENT_CONTRACT
+            );
+    }
+}

--- a/test/TradeAboveThreshold.t.sol
+++ b/test/TradeAboveThreshold.t.sol
@@ -18,7 +18,7 @@ contract TradeAboveThresholdTest is Test {
     function setUp() public {
         sellToken = IERC20(0x1);
         buyToken = IERC20(0x2);
-        receiver = address(0x3);
+        receiver = address(0x0);
         settlement = new GPv2Settlement(GPv2Authentication(0), IVault(0));
 
         //mock approval


### PR DESCRIPTION
Cf. updated README for explanation and a test plan on why this is desirable.

TradeAfterThreshold was updated to instead of implicitly checking balances for itself it can now check balances of a "target" contract and will sign off orders on behalf of this contract instead of self. This means we can create a new instance for each Safe and use it as a fallbackHandler which will automatically validate trades on behalf of this Safe.

This also means the ConditionalOrder event needs to emit the address of the target contract (as this is the one the watcher needs to monitor)

I built a simple factory contract to allow easy deployment via the Safe UI (cf Readme). I should probably start adding artefact information to the repo (at this point I'm using `forge create` which doesn't record any metadata about the deployment). I will leave this to a later PR.

For now, we can test the deployed factories at:
- https://blockscout.com/xdai/mainnet/address/0x66510332b5EF19086eD5FEB533924ee8fA50f10A
- https://goerli.etherscan.io/address/0x58104dd6844e8aba70b37d69a1afa675f46c40cb