### PR TITLE
[Easy] fix event topic

### DIFF
--- a/tenderly.yaml
+++ b/tenderly.yaml
@@ -21,7 +21,7 @@ actions:
                 status: success
                 logEmitted:
                   startsWith: 
-                  - 0xa463d4c6494f3788b95f6cf2a5c8c1a63090dce890c49318a6f5f32dc51efcd1 
+                  - 0x348a1454f658b360fcb291e66a7adc4a65b64b38b956802a976d5e460d0e2084
       watch_orders:
         description: Checks on every block if the registered smart order contract wants to trade
         function: watch:checkForAndPlaceOrder


### PR DESCRIPTION
#4 changed the event (and updated the unit test) but forgot to update the event in the tenderly config (so the web3 action is still looking for old events)

Trivial fix (https://blockscout.com/xdai/mainnet/address/0x39638ea9F5DFc47a362fe5Dd5dF61bE37CF088d8/logs#address-tabs)