### PR TITLE
Perpetual Stable Swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository defined a common interface (`ConditionalOrder`) that all smart o
 The repository comes with one example contracts:
 
 - **TradeAboveThreshold:** Checks the contract's balance of a specific token and - if larger than a threshold - wants to trade all of it into a specified buy token.
+- **PerpetualStableSwap:** Takes a token pair and is always willing to trade the token it has more balance of for the other one at a rate 1:1 + a specified spread.
 
 Check `src/` for a full list and implementation details. In order to deploy one of the contracts for your own use case, execute the following steps:
 

--- a/src/PerpetualStableSwap.sol
+++ b/src/PerpetualStableSwap.sol
@@ -22,6 +22,13 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
     // There are 10k basis points in a unit
     uint256 public constant BPS = 10_000;
 
+    /**
+     * Creates a new perpetual swap order. All resulting swaps will be made from the target contract.
+     * @param _tokenA One of the two tokens that can be perpetually swapped against one another
+     * @param _tokenB The other of the two tokens that can be perpetually swapped against one another
+     * @param _halfSpreadBps The markup to parity (ie 1:1 exchange rate) that is charged for each swap
+     * @param _target The contract holding the relevant balances (e.g a target Safe) or 0 if this contract.
+     */
     constructor(
         IERC20 _tokenA,
         IERC20 _tokenB,
@@ -83,8 +90,8 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
 
         // Unless spread is 0 (and there is no surplus), order collision is not an issue as sell and buy amounts should
         // increase for each subsequent order. We therefore set validity to a large time span
-        // Note, that reducing currenbt block to a common start time is needed so that the order returned here
-        // does not change between the time it is queried and the time it is settled.
+        // Note, that reducing current block to a common start time is needed so that the order returned here
+        // does not change between the time it is queried and the time it is settled. Validity will be between 1 & 2 weeks.
         uint32 validity = 1 weeks;
         // solhint-disable-next-line not-rely-on-time
         uint32 currentTimeBucket = ((uint32(block.timestamp) / validity) + 1) *

--- a/src/PerpetualStableSwap.sol
+++ b/src/PerpetualStableSwap.sol
@@ -134,8 +134,7 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
         bytes calldata
     ) external view override returns (bytes4) {
         require(
-            getTradeableOrder().hash(domainSeparator) ==
-                orderDigest,
+            getTradeableOrder().hash(domainSeparator) == orderDigest,
             "encoded order != tradable order"
         );
 

--- a/src/PerpetualStableSwap.sol
+++ b/src/PerpetualStableSwap.sol
@@ -58,7 +58,7 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
     }
 
     function getTradeableOrder()
-        external
+        public
         view
         override
         returns (GPv2Order.Data memory)
@@ -134,7 +134,7 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
         bytes calldata
     ) external view override returns (bytes4) {
         require(
-            ConditionalOrder(this).getTradeableOrder().hash(domainSeparator) ==
+            getTradeableOrder().hash(domainSeparator) ==
                 orderDigest,
             "encoded order != tradable order"
         );

--- a/src/PerpetualStableSwap.sol
+++ b/src/PerpetualStableSwap.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "./ConditionalOrder.sol";
+import "lib/contracts/src/contracts/GPv2Settlement.sol";
+import "lib/contracts/src/contracts/interfaces/GPv2EIP1271.sol";
+
+// @title A smart contract that is always willing to trade between tokenA and tokenB 1:1,
+// taking decimals into account (and adding specifiable spread)
+contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
+    using GPv2Order for GPv2Order.Data;
+    using SafeMath for uint256;
+    using SafeMath for uint8;
+
+    IERC20 public immutable tokenA;
+    IERC20 public immutable tokenB;
+    uint256 public immutable halfSpreadBps;
+    address public immutable target;
+    bytes32 domainSeparator;
+
+    // There are 10k basis points in a unit
+    uint256 public constant BPS = 10_000;
+
+    constructor(
+        IERC20 _tokenA,
+        IERC20 _tokenB,
+        uint256 _halfSpreadBps,
+        address _target,
+        GPv2Settlement _settlementContract
+    ) {
+        tokenA = _tokenA;
+        tokenB = _tokenB;
+        halfSpreadBps = _halfSpreadBps;
+        domainSeparator = _settlementContract.domainSeparator();
+
+        if (_target == address(0)) {
+            _target = address(this);
+            // Otherwise we expect the target to set allowance itself
+            _tokenA.approve(
+                address(_settlementContract.vaultRelayer()),
+                uint(-1)
+            );
+            _tokenB.approve(
+                address(_settlementContract.vaultRelayer()),
+                uint(-1)
+            );
+        } 
+        target = _target;
+        emit ConditionalOrderCreated(_target);
+    }
+
+    function getTradeableOrder()
+        external
+        view
+        override
+        returns (GPv2Order.Data memory)
+    {
+        uint256 balanceA = tokenA.balanceOf(target);
+        uint256 balanceB = tokenB.balanceOf(target);
+
+        // Always sell whatever of the two tokens we have more of
+        IERC20 sellToken;
+        IERC20 buyToken;
+        uint256 sellAmount;
+        uint256 buyAmount;
+        if (convertAmount(tokenA, balanceA, tokenB) > balanceB) {
+            sellToken = tokenA;
+            buyToken = tokenB;
+            sellAmount = balanceA;
+            buyAmount = convertAmount(tokenA, balanceA, tokenB).mul(BPS.add(halfSpreadBps)).div(BPS);
+        } else {
+            sellToken = tokenB;
+            buyToken = tokenA;
+            sellAmount = balanceB;
+            buyAmount = convertAmount(tokenB, balanceB, tokenA).mul(BPS.add(halfSpreadBps)).div(BPS);
+        }
+        require(sellAmount > 0, "not funded");
+
+        // Unless spread is 0 (and there is no surplus), order collision is not an issue as sell and buy amounts should
+        // increase for each subsequent order. We therefore set validity to a large time span
+        // Note, that reducing currenbt block to a common start time is needed so that the order returned here
+        // does not change between the time it is queried and the time it is settled.
+        uint32 validity = 1 weeks;
+        uint32 currentTimeBucket = ((uint32(block.timestamp) / validity) + 1) * validity;
+        return
+            GPv2Order.Data(
+                sellToken,
+                buyToken,
+                target,
+                sellAmount,
+                buyAmount,
+                currentTimeBucket + validity,
+                keccak256("PerpetualStableSwap"),
+                0,
+                GPv2Order.KIND_SELL,
+                false,
+                GPv2Order.BALANCE_ERC20,
+                GPv2Order.BALANCE_ERC20
+            );
+    }
+
+    function convertAmount(
+        IERC20 srcToken,
+        uint256 srcAmount,
+        IERC20 destToken
+    ) public view returns (uint256 destAmount) {
+        uint8 srcDecimals = srcToken.decimals();
+        uint8 destDecimals = destToken.decimals();
+
+        if (srcDecimals > destDecimals) {
+            destAmount = srcAmount.div(10**(srcDecimals.sub(destDecimals)));
+        } else {
+            destAmount = srcAmount.mul(10**(destDecimals.sub(srcDecimals)));
+        }
+    }
+
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    function isValidSignature(
+        bytes32 orderDigest,
+        bytes calldata
+    ) external view override returns (bytes4) {
+        require(
+            ConditionalOrder(this).getTradeableOrder().hash(domainSeparator) ==
+                orderDigest,
+            "encoded order != tradable order"
+        );
+
+        return GPv2EIP1271.MAGICVALUE;
+    }
+}

--- a/src/PerpetualStableSwap.sol
+++ b/src/PerpetualStableSwap.sol
@@ -17,7 +17,7 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
     IERC20 public immutable tokenB;
     uint256 public immutable halfSpreadBps;
     address public immutable target;
-    bytes32 domainSeparator;
+    bytes32 public domainSeparator;
 
     // There are 10k basis points in a unit
     uint256 public constant BPS = 10_000;
@@ -45,7 +45,7 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
                 address(_settlementContract.vaultRelayer()),
                 uint(-1)
             );
-        } 
+        }
         target = _target;
         emit ConditionalOrderCreated(_target);
     }
@@ -68,12 +68,16 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
             sellToken = tokenA;
             buyToken = tokenB;
             sellAmount = balanceA;
-            buyAmount = convertAmount(tokenA, balanceA, tokenB).mul(BPS.add(halfSpreadBps)).div(BPS);
+            buyAmount = convertAmount(tokenA, balanceA, tokenB)
+                .mul(BPS.add(halfSpreadBps))
+                .div(BPS);
         } else {
             sellToken = tokenB;
             buyToken = tokenA;
             sellAmount = balanceB;
-            buyAmount = convertAmount(tokenB, balanceB, tokenA).mul(BPS.add(halfSpreadBps)).div(BPS);
+            buyAmount = convertAmount(tokenB, balanceB, tokenA)
+                .mul(BPS.add(halfSpreadBps))
+                .div(BPS);
         }
         require(sellAmount > 0, "not funded");
 
@@ -82,7 +86,9 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
         // Note, that reducing currenbt block to a common start time is needed so that the order returned here
         // does not change between the time it is queried and the time it is settled.
         uint32 validity = 1 weeks;
-        uint32 currentTimeBucket = ((uint32(block.timestamp) / validity) + 1) * validity;
+        // solhint-disable-next-line not-rely-on-time
+        uint32 currentTimeBucket = ((uint32(block.timestamp) / validity) + 1) *
+            validity;
         return
             GPv2Order.Data(
                 sellToken,
@@ -109,9 +115,9 @@ contract PerpetualStableSwap is ConditionalOrder, EIP1271Verifier {
         uint8 destDecimals = destToken.decimals();
 
         if (srcDecimals > destDecimals) {
-            destAmount = srcAmount.div(10**(srcDecimals.sub(destDecimals)));
+            destAmount = srcAmount.div(10 ** (srcDecimals.sub(destDecimals)));
         } else {
-            destAmount = srcAmount.mul(10**(destDecimals.sub(srcDecimals)));
+            destAmount = srcAmount.mul(10 ** (destDecimals.sub(srcDecimals)));
         }
     }
 

--- a/src/factories/PerpetualStableSwapFactory.sol
+++ b/src/factories/PerpetualStableSwapFactory.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "../PerpetualStableSwap.sol";
+
+// @title A factory to create `PerpetualStableSwap` order instances
+contract PerpetualStableSwapFactory {
+    GPv2Settlement constant SETTLEMENT_CONTRACT =
+        GPv2Settlement(0x9008D19f58AAbD9eD0D60971565AA8510560ab41);
+
+    function create(
+        IERC20 tokenA,
+        IERC20 tokenB,
+        uint256 halfSpreadBps,
+        address target
+    ) external returns (PerpetualStableSwap) {
+        return
+            new PerpetualStableSwap(
+                tokenA,
+                tokenB,
+                halfSpreadBps,
+                target,
+                SETTLEMENT_CONTRACT
+            );
+    }
+}

--- a/src/factories/PerpetualStableSwapFactory.sol
+++ b/src/factories/PerpetualStableSwapFactory.sol
@@ -6,7 +6,7 @@ import "../PerpetualStableSwap.sol";
 
 // @title A factory to create `PerpetualStableSwap` order instances
 contract PerpetualStableSwapFactory {
-    GPv2Settlement constant SETTLEMENT_CONTRACT =
+    GPv2Settlement public constant SETTLEMENT_CONTRACT =
         GPv2Settlement(0x9008D19f58AAbD9eD0D60971565AA8510560ab41);
 
     function create(

--- a/test/PerpetualStableSwap.t.sol
+++ b/test/PerpetualStableSwap.t.sol
@@ -10,7 +10,7 @@ contract PerpetualStableSwapTest is Test {
     using GPv2Order for GPv2Order.Data;
 
     PerpetualStableSwap public instance;
-    GPv2Settlement settlement;
+    GPv2Settlement public settlement;
     IERC20 public tokenA;
     IERC20 public tokenB;
     address public receiver;
@@ -58,7 +58,13 @@ contract PerpetualStableSwapTest is Test {
         require(order.buyToken == tokenA, "Wrong buy token");
         require(order.sellAmount == 2e19, "Wrong sell amount");
         require(order.buyAmount == 2e19 + 2e17, "Wrong buy amount");
-        require(instance.isValidSignature(order.hash(settlement.domainSeparator()), "") == GPv2EIP1271.MAGICVALUE, "Tradeable order doesn't pass signature check");
+        require(
+            instance.isValidSignature(
+                order.hash(settlement.domainSeparator()),
+                ""
+            ) == GPv2EIP1271.MAGICVALUE,
+            "Order failed signature check"
+        );
     }
 
     function testTradesTokensWithDifferentDecimals() public {
@@ -82,7 +88,13 @@ contract PerpetualStableSwapTest is Test {
         require(order.buyToken == tokenB, "Wrong buy token");
         require(order.sellAmount == 2e18, "Wrong sell amount");
         require(order.buyAmount == 2e6 + 2e4, "Wrong buy amount");
-        require(instance.isValidSignature(order.hash(settlement.domainSeparator()), "") == GPv2EIP1271.MAGICVALUE, "Tradeable order doesn't pass signature check");
+        require(
+            instance.isValidSignature(
+                order.hash(settlement.domainSeparator()),
+                ""
+            ) == GPv2EIP1271.MAGICVALUE,
+            "Order failed signature check"
+        );
 
         //Lower decimal token has more balance
         setBalance(tokenB, 3e6);
@@ -92,7 +104,13 @@ contract PerpetualStableSwapTest is Test {
         require(order.buyToken == tokenA, "Wrong buy token");
         require(order.sellAmount == 3e6, "Wrong sell amount");
         require(order.buyAmount == 3e18 + 3e16, "Wrong buy amount");
-        require(instance.isValidSignature(order.hash(settlement.domainSeparator()), "") == GPv2EIP1271.MAGICVALUE, "Tradeable order doesn't pass signature check");
+        require(
+            instance.isValidSignature(
+                order.hash(settlement.domainSeparator()),
+                ""
+            ) == GPv2EIP1271.MAGICVALUE,
+            "Order failed signature check"
+        );
     }
 
     function testValidity() public {
@@ -112,10 +130,10 @@ contract PerpetualStableSwapTest is Test {
 
         vm.warp(1671436380); // Mon Dec 19
         GPv2Order.Data memory order = instance.getTradeableOrder();
-        require(order.validTo == 1672272000); // Thu Dec 29
+        require(order.validTo == 1672272000, "Should be Thu Dec 29");
 
         vm.warp(1671667200); // Thu Dec 22
         order = instance.getTradeableOrder();
-        require(order.validTo == 1672876800); // Thu Jan 5
+        require(order.validTo == 1672876800, "Should be Thu Jan 5");
     }
 }

--- a/test/PerpetualStableSwap.t.sol
+++ b/test/PerpetualStableSwap.t.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma abicoder v2;
+pragma solidity ^0.7.6;
+
+import "forge-std/Test.sol";
+import "../src/PerpetualStableSwap.sol";
+import "lib/contracts/src/contracts/interfaces/GPv2EIP1271.sol";
+
+contract PerpetualStableSwapTest is Test {
+    using GPv2Order for GPv2Order.Data;
+
+    PerpetualStableSwap public instance;
+    GPv2Settlement settlement;
+    IERC20 public tokenA;
+    IERC20 public tokenB;
+    address public receiver;
+
+    function setUp() public {
+        tokenA = IERC20(0x1);
+        tokenB = IERC20(0x2);
+        receiver = address(0x3);
+        settlement = new GPv2Settlement(GPv2Authentication(0), IVault(0));
+    }
+
+    function setBalance(IERC20 token, uint256 balance) private {
+        vm.mockCall(
+            address(token),
+            abi.encodeWithSelector(token.balanceOf.selector, receiver),
+            abi.encode(balance)
+        );
+    }
+
+    function setDecimals(IERC20 token, uint8 decimals) private {
+        vm.mockCall(
+            address(token),
+            abi.encodeWithSelector(token.decimals.selector),
+            abi.encode(decimals)
+        );
+    }
+
+    function testTradesTokenWithLargerBalance() public {
+        uint256 halfSpreadBps = 100;
+        instance = new PerpetualStableSwap(
+            tokenA,
+            tokenB,
+            halfSpreadBps,
+            receiver,
+            settlement
+        );
+
+        setDecimals(tokenA, 18);
+        setDecimals(tokenB, 18);
+        setBalance(tokenA, 1e19);
+        setBalance(tokenB, 2e19);
+
+        GPv2Order.Data memory order = instance.getTradeableOrder();
+        require(order.sellToken == tokenB, "Wrong sell token");
+        require(order.buyToken == tokenA, "Wrong buy token");
+        require(order.sellAmount == 2e19, "Wrong sell amount");
+        require(order.buyAmount == 2e19 + 2e17, "Wrong buy amount");
+        require(instance.isValidSignature(order.hash(settlement.domainSeparator()), "") == GPv2EIP1271.MAGICVALUE, "Tradeable order doesn't pass signature check");
+    }
+
+    function testTradesTokensWithDifferentDecimals() public {
+        uint256 halfSpreadBps = 100;
+        instance = new PerpetualStableSwap(
+            tokenA,
+            tokenB,
+            halfSpreadBps,
+            receiver,
+            settlement
+        );
+
+        //Larger decimal token has more balance
+        setDecimals(tokenA, 18);
+        setDecimals(tokenB, 6);
+        setBalance(tokenA, 2e18);
+        setBalance(tokenB, 1e6);
+
+        GPv2Order.Data memory order = instance.getTradeableOrder();
+        require(order.sellToken == tokenA, "Wrong sell token");
+        require(order.buyToken == tokenB, "Wrong buy token");
+        require(order.sellAmount == 2e18, "Wrong sell amount");
+        require(order.buyAmount == 2e6 + 2e4, "Wrong buy amount");
+        require(instance.isValidSignature(order.hash(settlement.domainSeparator()), "") == GPv2EIP1271.MAGICVALUE, "Tradeable order doesn't pass signature check");
+
+        //Lower decimal token has more balance
+        setBalance(tokenB, 3e6);
+
+        order = instance.getTradeableOrder();
+        require(order.sellToken == tokenB, "Wrong sell token");
+        require(order.buyToken == tokenA, "Wrong buy token");
+        require(order.sellAmount == 3e6, "Wrong sell amount");
+        require(order.buyAmount == 3e18 + 3e16, "Wrong buy amount");
+        require(instance.isValidSignature(order.hash(settlement.domainSeparator()), "") == GPv2EIP1271.MAGICVALUE, "Tradeable order doesn't pass signature check");
+    }
+
+    function testValidity() public {
+        uint256 halfSpreadBps = 100;
+        instance = new PerpetualStableSwap(
+            tokenA,
+            tokenB,
+            halfSpreadBps,
+            receiver,
+            settlement
+        );
+
+        setDecimals(tokenA, 18);
+        setDecimals(tokenB, 18);
+        setBalance(tokenA, 1e18);
+        setBalance(tokenB, 1e18);
+
+        vm.warp(1671436380); // Mon Dec 19
+        GPv2Order.Data memory order = instance.getTradeableOrder();
+        require(order.validTo == 1672272000); // Thu Dec 29
+
+        vm.warp(1671667200); // Thu Dec 22
+        order = instance.getTradeableOrder();
+        require(order.validTo == 1672876800); // Thu Jan 5
+    }
+}


### PR DESCRIPTION
A new order type that allows swapping two tokens at parity plus a predefined spread. E.g. if instantiated with USDC/DAI and a spread of 10bps the contract will always swap its entire balance of one token at a price 1.001 and vice versa.

This allows to create automated liquidity orders for stablecoins which can hopefully facilitate more CoWs.

### Test Plan

Unit tests