### PR TITLE
WaitForCow Smart Order Type

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = lib/contracts
 	url = https://github.com/cowprotocol/contracts
 	branch = v1.3.1
+[submodule "lib/milkman"]
+	path = lib/milkman
+	url = https://github.com/charlesndalton/milkman

--- a/src/WaitForCoWOrder.sol
+++ b/src/WaitForCoWOrder.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "lib/contracts/src/contracts/GPv2Settlement.sol";
+import "lib/contracts/src/contracts/interfaces/GPv2EIP1271.sol";
+import "lib/milkman/contracts/pricecheckers/IExpectedOutCalculator.sol";
+
+// @title A smart contract that is always willing to trade token A for B as long
+// as the price is better than some on-chain reference. Thus, this liquidity can be
+// used to replace interactions that would otherwise use this reference liquidity
+// source to settle another user order.
+contract WaitForCoWOrder is EIP1271Verifier {
+    event WaitForCoWOrderCreated(address indexed);
+
+    using GPv2Order for GPv2Order.Data;
+    using SafeMath for uint256;
+
+    // There are 10k basis points in a unit
+    uint256 public constant BPS = 10_000;
+
+    IERC20 public immutable sellToken;
+    IERC20 public immutable buyToken;
+    address public immutable target;
+    bytes32 public immutable domainSeparator;
+
+    IExpectedOutCalculator public immutable expectedOutCalculator;
+    bytes public expectedOutCalculatorCalldata;
+    uint256 public slippageToleranceBps;
+
+    /**
+     * Creates a new wait-for-cow order. All resulting swaps will be made from the target contract.
+     * @param _sellToken The token that we are willing to sell
+     * @param _buyToken The other that we are willing to buy
+     * @param _target The contract holding the relevant balances (e.g a target Safe)
+     * @param _settlementContract The CoW Protocol settlement contract
+     * @param _expectedOutCalculator The contract which is used to check the reference liquidity
+     * @param _expectedOutCalculatorCalldata The calldata provided into the reference checker
+     * @param _slippageToleranceBps How much discount from the reference price you are willing to match.
+     * In order to match at the current spot price this should be the same as the pool's fee.
+     */
+    constructor(
+        IERC20 _sellToken,
+        IERC20 _buyToken,
+        address _target,
+        GPv2Settlement _settlementContract,
+        IExpectedOutCalculator _expectedOutCalculator,
+        bytes memory _expectedOutCalculatorCalldata,
+        uint256 _slippageToleranceBps
+    ) {
+        sellToken = _sellToken;
+        buyToken = _buyToken;
+        domainSeparator = _settlementContract.domainSeparator();
+        target = _target;
+        expectedOutCalculator = _expectedOutCalculator;
+        expectedOutCalculatorCalldata = _expectedOutCalculatorCalldata;
+        slippageToleranceBps = _slippageToleranceBps;
+
+        require(_target != address(0), "Need a target");
+        emit WaitForCoWOrderCreated(_target);
+    }
+
+    function getTradeableOrder() public view returns (GPv2Order.Data memory) {
+        // Check how much we would get for 1 unit.
+        uint256 expectedOutForOneUnit = expectedOutCalculator.getExpectedOut(
+            10 ** sellToken.decimals(),
+            address(sellToken),
+            address(buyToken),
+            expectedOutCalculatorCalldata
+        );
+        // Increase out amount by half spread (to get to mid point)
+        expectedOutForOneUnit = expectedOutForOneUnit.mul(BPS.add(slippageToleranceBps)).div(BPS);
+        
+        // Assume zero price impact
+        uint256 sellAmount = sellToken.balanceOf(target);
+        uint256 buyAmount = expectedOutForOneUnit.mul(sellAmount) / 10 ** sellToken.decimals();
+
+        // solhint-disable-next-line not-rely-on-time
+        uint32 validTo = ((uint32(block.timestamp) / 3600) + 1) * 3600;
+        return
+            GPv2Order.Data(
+                sellToken,
+                buyToken,
+                target,
+                sellAmount,
+                buyAmount,
+                validTo,
+                keccak256("WaitForCoW"),
+                0,
+                GPv2Order.KIND_SELL,
+                false,
+                GPv2Order.BALANCE_ERC20,
+                GPv2Order.BALANCE_ERC20
+            );
+    }
+
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    function isValidSignature(
+        bytes32 orderDigest,
+        bytes calldata encodedOrder
+    ) external view override returns (bytes4) {
+        GPv2Order.Data memory order = abi.decode(
+            encodedOrder,
+            (GPv2Order.Data)
+        );
+        require(
+            order.hash(domainSeparator) == orderDigest,
+            "encoded order digest mismatch"
+        );
+
+        require(order.receiver == target, "Wrong recipient");
+        require(order.sellToken == sellToken, "Wrong sellToken");
+        require(order.buyToken == buyToken, "Wrong buyToken");
+        require(order.feeAmount == 0, "CoWs don't pay fees");
+        require(!order.partiallyFillable, "Match must be FoK");
+        require(
+            order.sellTokenBalance == GPv2Order.BALANCE_ERC20,
+            "Wrong Balance"
+        );
+        require(
+            order.buyTokenBalance == GPv2Order.BALANCE_ERC20,
+            "Wrong Balance"
+        );
+
+        // Check the order respects the limit price of the reference order
+        GPv2Order.Data memory limit = getTradeableOrder();
+
+        require(limit.sellAmount.mul(order.buyAmount) >= order.sellAmount.mul(limit.buyAmount), "Bad price");
+
+        return GPv2EIP1271.MAGICVALUE;
+    }
+}

--- a/src/WaitForCoWOrder.sol
+++ b/src/WaitForCoWOrder.sol
@@ -69,11 +69,14 @@ contract WaitForCoWOrder is EIP1271Verifier {
             expectedOutCalculatorCalldata
         );
         // Increase out amount by half spread (to get to mid point)
-        expectedOutForOneUnit = expectedOutForOneUnit.mul(BPS.add(slippageToleranceBps)).div(BPS);
-        
+        expectedOutForOneUnit = expectedOutForOneUnit
+            .mul(BPS.add(slippageToleranceBps))
+            .div(BPS);
+
         // Assume zero price impact
         uint256 sellAmount = sellToken.balanceOf(target);
-        uint256 buyAmount = expectedOutForOneUnit.mul(sellAmount) / 10 ** sellToken.decimals();
+        uint256 buyAmount = expectedOutForOneUnit.mul(sellAmount) /
+            10 ** sellToken.decimals();
 
         // solhint-disable-next-line not-rely-on-time
         uint32 validTo = ((uint32(block.timestamp) / 3600) + 1) * 3600;
@@ -125,7 +128,11 @@ contract WaitForCoWOrder is EIP1271Verifier {
         // Check the order respects the limit price of the reference order
         GPv2Order.Data memory limit = getTradeableOrder();
 
-        require(limit.sellAmount.mul(order.buyAmount) >= order.sellAmount.mul(limit.buyAmount), "Bad price");
+        require(
+            limit.sellAmount.mul(order.buyAmount) >=
+                order.sellAmount.mul(limit.buyAmount),
+            "Bad price"
+        );
 
         return GPv2EIP1271.MAGICVALUE;
     }

--- a/src/factories/WaitForCoWFactory.sol
+++ b/src/factories/WaitForCoWFactory.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "../WaitForCoWOrder.sol";
+
+// @title A factory to create `WaitForCoW` order instances
+contract PerpetualStableSwapFactory {
+    GPv2Settlement public constant SETTLEMENT_CONTRACT =
+        GPv2Settlement(0x9008D19f58AAbD9eD0D60971565AA8510560ab41);
+
+    function create(
+        IERC20 sellToken,
+        IERC20 buyToken,
+        address target,
+        IExpectedOutCalculator expectedOutCalculator,
+        bytes calldata expectedOutCalculatorCalldata,
+        uint256 halfSpreadBps
+    ) external returns (WaitForCoWOrder) {
+        return
+            new WaitForCoWOrder(
+                sellToken,
+                buyToken,
+                target,
+                SETTLEMENT_CONTRACT,
+                expectedOutCalculator,
+                expectedOutCalculatorCalldata,
+                halfSpreadBps
+            );
+    }
+}

--- a/test/PerpetualStableSwap.t.sol
+++ b/test/PerpetualStableSwap.t.sol
@@ -3,6 +3,7 @@ pragma abicoder v2;
 pragma solidity ^0.7.6;
 
 import "forge-std/Test.sol";
+import "./libraries/TestLib.t.sol";
 import "../src/PerpetualStableSwap.sol";
 import "lib/contracts/src/contracts/interfaces/GPv2EIP1271.sol";
 
@@ -22,22 +23,6 @@ contract PerpetualStableSwapTest is Test {
         settlement = new GPv2Settlement(GPv2Authentication(0), IVault(0));
     }
 
-    function setBalance(IERC20 token, uint256 balance) private {
-        vm.mockCall(
-            address(token),
-            abi.encodeWithSelector(token.balanceOf.selector, receiver),
-            abi.encode(balance)
-        );
-    }
-
-    function setDecimals(IERC20 token, uint8 decimals) private {
-        vm.mockCall(
-            address(token),
-            abi.encodeWithSelector(token.decimals.selector),
-            abi.encode(decimals)
-        );
-    }
-
     function testTradesTokenWithLargerBalance() public {
         uint256 halfSpreadBps = 100;
         instance = new PerpetualStableSwap(
@@ -48,10 +33,10 @@ contract PerpetualStableSwapTest is Test {
             settlement
         );
 
-        setDecimals(tokenA, 18);
-        setDecimals(tokenB, 18);
-        setBalance(tokenA, 1e19);
-        setBalance(tokenB, 2e19);
+        TestLib.setDecimals(vm, tokenA, 18);
+        TestLib.setDecimals(vm, tokenB, 18);
+        TestLib.setBalance(vm, tokenA, 1e19, receiver);
+        TestLib.setBalance(vm, tokenB, 2e19, receiver);
 
         GPv2Order.Data memory order = instance.getTradeableOrder();
         require(order.sellToken == tokenB, "Wrong sell token");
@@ -78,10 +63,10 @@ contract PerpetualStableSwapTest is Test {
         );
 
         //Larger decimal token has more balance
-        setDecimals(tokenA, 18);
-        setDecimals(tokenB, 6);
-        setBalance(tokenA, 2e18);
-        setBalance(tokenB, 1e6);
+        TestLib.setDecimals(vm, tokenA, 18);
+        TestLib.setDecimals(vm, tokenB, 6);
+        TestLib.setBalance(vm, tokenA, 2e18, receiver);
+        TestLib.setBalance(vm, tokenB, 1e6, receiver);
 
         GPv2Order.Data memory order = instance.getTradeableOrder();
         require(order.sellToken == tokenA, "Wrong sell token");
@@ -97,7 +82,7 @@ contract PerpetualStableSwapTest is Test {
         );
 
         //Lower decimal token has more balance
-        setBalance(tokenB, 3e6);
+        TestLib.setBalance(vm, tokenB, 3e6, receiver);
 
         order = instance.getTradeableOrder();
         require(order.sellToken == tokenB, "Wrong sell token");
@@ -123,10 +108,10 @@ contract PerpetualStableSwapTest is Test {
             settlement
         );
 
-        setDecimals(tokenA, 18);
-        setDecimals(tokenB, 18);
-        setBalance(tokenA, 1e18);
-        setBalance(tokenB, 1e18);
+        TestLib.setDecimals(vm, tokenA, 18);
+        TestLib.setDecimals(vm, tokenB, 18);
+        TestLib.setBalance(vm, tokenA, 1e18, receiver);
+        TestLib.setBalance(vm, tokenB, 1e18, receiver);
 
         vm.warp(1671436380); // Mon Dec 19
         GPv2Order.Data memory order = instance.getTradeableOrder();

--- a/test/WaitForCoWOrder.t.sol
+++ b/test/WaitForCoWOrder.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma abicoder v2;
+pragma solidity ^0.7.6;
+
+import "forge-std/Test.sol";
+import "../src/WaitForCoWOrder.sol";
+import "./libraries/TestLib.t.sol";
+import "lib/contracts/src/contracts/interfaces/GPv2EIP1271.sol";
+
+contract WaitForCowOrderTest is Test {
+    using GPv2Order for GPv2Order.Data;
+
+    WaitForCoWOrder public instance;
+    IERC20 public constant SELL_TOKEN = IERC20(0x1);
+    IERC20 public constant BUY_TOKEN = IERC20(0x2);
+    address public constant RECEIVER = address(0x3);
+    IExpectedOutCalculator public constant EXPECTED_OUT_CALCULATOR =
+        IExpectedOutCalculator(0x4);
+    bytes public constant EXPECTED_OUT_CALLDATA = "0x";
+    GPv2Settlement public settlement;
+    GPv2Order.Data public order;
+
+    function setUp() public {
+        uint256 slippageToleranceBps = 5;
+        settlement = new GPv2Settlement(GPv2Authentication(0), IVault(0));
+
+        instance = new WaitForCoWOrder(
+            SELL_TOKEN,
+            BUY_TOKEN,
+            RECEIVER,
+            settlement,
+            EXPECTED_OUT_CALCULATOR,
+            EXPECTED_OUT_CALLDATA,
+            slippageToleranceBps
+        );
+
+        order = GPv2Order.Data({
+            sellToken: SELL_TOKEN,
+            buyToken: BUY_TOKEN,
+            receiver: RECEIVER,
+            sellAmount: 0,
+            buyAmount: 0,
+            feeAmount: 0,
+            appData: bytes32(0),
+            validTo: 0,
+            kind: GPv2Order.KIND_SELL,
+            partiallyFillable: false,
+            sellTokenBalance: GPv2Order.BALANCE_ERC20,
+            buyTokenBalance: GPv2Order.BALANCE_ERC20
+        });
+
+        TestLib.setBalance(vm, SELL_TOKEN, 10000e18, RECEIVER);
+        TestLib.setDecimals(vm, SELL_TOKEN, 18);
+        TestLib.setDecimals(vm, BUY_TOKEN, 18);
+    }
+
+    function testGoodPrice() public {
+        order.sellAmount = 9995e18;
+        order.buyAmount = 10000e18;
+
+        vm.mockCall(
+            address(EXPECTED_OUT_CALCULATOR),
+            abi.encodeWithSelector(
+                EXPECTED_OUT_CALCULATOR.getExpectedOut.selector,
+                1e18,
+                SELL_TOKEN,
+                BUY_TOKEN
+            ),
+            abi.encode(0.9995e18)
+        );
+        require(
+            instance.isValidSignature(
+                order.hash(settlement.domainSeparator()),
+                abi.encode(order)
+            ) == GPv2EIP1271.MAGICVALUE,
+            "Order failed signature check"
+        );
+    }
+
+    function testLimitPrice() public {
+        order.sellAmount = 10000e18;
+        order.buyAmount = 10000e18;
+
+        vm.mockCall(
+            address(EXPECTED_OUT_CALCULATOR),
+            abi.encodeWithSelector(
+                EXPECTED_OUT_CALCULATOR.getExpectedOut.selector,
+                1e18,
+                SELL_TOKEN,
+                BUY_TOKEN
+            ),
+            abi.encode(0.9995e18)
+        );
+        require(
+            instance.isValidSignature(
+                order.hash(settlement.domainSeparator()),
+                abi.encode(order)
+            ) == GPv2EIP1271.MAGICVALUE,
+            "Order failed signature check"
+        );
+    }
+
+    function testBadPrice() public {
+        order.sellAmount = 10001e18;
+        order.buyAmount = 10000e18;
+
+        vm.mockCall(
+            address(EXPECTED_OUT_CALCULATOR),
+            abi.encodeWithSelector(
+                EXPECTED_OUT_CALCULATOR.getExpectedOut.selector,
+                1e18,
+                SELL_TOKEN,
+                BUY_TOKEN
+            ),
+            abi.encode(0.9995e18)
+        );
+
+        bytes32 hash = order.hash(settlement.domainSeparator());
+        bytes memory encodedOrder = abi.encode(order);
+        vm.expectRevert("Bad price");
+        instance.isValidSignature(hash, encodedOrder);
+    }
+}

--- a/test/libraries/TestLib.t.sol
+++ b/test/libraries/TestLib.t.sol
@@ -5,7 +5,12 @@ import "lib/contracts/src/contracts/interfaces/IERC20.sol";
 import "forge-std/Test.sol";
 
 library TestLib {
-    function setBalance(Vm vm, IERC20 token, uint256 balance, address owner) public {
+    function setBalance(
+        Vm vm,
+        IERC20 token,
+        uint256 balance,
+        address owner
+    ) public {
         vm.mockCall(
             address(token),
             abi.encodeWithSelector(token.balanceOf.selector, owner),

--- a/test/libraries/TestLib.t.sol
+++ b/test/libraries/TestLib.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.6;
+
+import "lib/contracts/src/contracts/interfaces/IERC20.sol";
+import "forge-std/Test.sol";
+
+library TestLib {
+    function setBalance(Vm vm, IERC20 token, uint256 balance, address owner) public {
+        vm.mockCall(
+            address(token),
+            abi.encodeWithSelector(token.balanceOf.selector, owner),
+            abi.encode(balance)
+        );
+    }
+
+    function setDecimals(Vm vm, IERC20 token, uint8 decimals) public {
+        vm.mockCall(
+            address(token),
+            abi.encodeWithSelector(token.decimals.selector),
+            abi.encode(decimals)
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a new smart order type that is willing to trade whatever fraction of its remaining sell balance whenever the offered price is the same or better than a price milkman style price estimator.

This logic can be used for partially fillable "WaitForCoW" orders (e.g. a DAO selling a large amount of tokens). WaitForCoW orders should only be matched against other users. While we cannot guarantee this, we can use the heuristic that if the clearing price is between the most liquid bid ask spread (ideally at the current spot price of the most liquid pool), it means that someone is trading against us that would otherwise trade at the - for them - less favorable AMM ask (and we get to still trade at a price more favorable price compared to the AMM bid).

Concretley, we achieve this by e.g. using an expected out estimator and adding a negative slippage tolerance to it (in the future we could maybe use the DynamicPriceChecker if it allowed for negative values as well)

The following diagram visualizes the idea and how solvers can utilize WaitForCoW orders to generate more user surplus and therefore have a higher chance of winning:

<img src="https://user-images.githubusercontent.com/1200333/222973586-b5094675-eda8-4153-9e17-ccf241dba664.png" width="500">

## Test Plan

- An instance of the contract is deployed at 0xaba85e9588e3aee87c19ed5809d6d42a29831fa8
- A safe selling 100 USDC for ETH using this order as fallback handler is deployed at 0x1FC631d6e8B6dce4CCF4B54f5BE81bc7F02415b2
- https://etherscan.io/address/0xe84dcd8587287b997f51299430a396ad03aaec06#readContract can be used to generate a sample order that the contract is willing to accept (e.g. use `getTradeableOrder` on the instance to indicate the exchange rate)

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/1200333/222974384-5e289f5e-2d83-4c0c-9677-0a01cfd09e3d.png">
